### PR TITLE
Add accessible mobile navigation toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,17 @@
         <span class="logo" aria-hidden="true"></span>
         <span>Pårørendehjælp</span>
       </a>
-      <ul>
-        <li><a href="#hjemmet">Genoptræning i hjemmet</a></li>
-        <li><a href="#stoette">Hvordan kan du støtte?</a></li>
-        <li><a href="#elementer">Vigtige elementer</a></li>
-        <li><a href="#ressourcer" class="cta">Ressourcer</a></li>
-      </ul>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+        Menu
+      </button>
+      <div class="nav-menu" id="primary-navigation">
+        <ul>
+          <li><a href="#hjemmet">Genoptræning i hjemmet</a></li>
+          <li><a href="#stoette">Hvordan kan du støtte?</a></li>
+          <li><a href="#elementer">Vigtige elementer</a></li>
+          <li><a href="#ressourcer" class="cta">Ressourcer</a></li>
+        </ul>
+      </div>
     </div>
   </header>
 
@@ -127,5 +132,61 @@
       <div>Bygget på indhold fra <a href="https://www.hjernesagen.dk/" target="_blank" rel="noopener noreferrer">Hjernesagen</a> og <a href="https://www.sundhed.dk/" target="_blank" rel="noopener noreferrer">Sundhed.dk</a>.</div>
     </div>
   </footer>
+  <script>
+    const navToggle = document.querySelector('.nav-toggle');
+    const navMenu = document.getElementById('primary-navigation');
+    const navContainer = document.querySelector('.nav');
+
+    if (navToggle && navMenu && navContainer) {
+      navContainer.classList.add('has-toggle');
+      const mobileQuery = window.matchMedia('(max-width: 960px)');
+      const menuLinks = navMenu.querySelectorAll('a');
+
+      const setMenuState = (isOpen) => {
+        navMenu.classList.toggle('is-open', isOpen);
+        navMenu.setAttribute('aria-hidden', String(!isOpen));
+        if (isOpen) {
+          navMenu.removeAttribute('inert');
+        } else {
+          navMenu.setAttribute('inert', '');
+        }
+        menuLinks.forEach((link) => {
+          if (isOpen) {
+            link.removeAttribute('tabindex');
+          } else {
+            link.setAttribute('tabindex', '-1');
+          }
+        });
+      };
+
+      const syncMenuWithViewport = () => {
+        if (mobileQuery.matches) {
+          const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+          setMenuState(expanded);
+        } else {
+          navToggle.setAttribute('aria-expanded', 'false');
+          navMenu.classList.remove('is-open');
+          navMenu.removeAttribute('aria-hidden');
+          navMenu.removeAttribute('inert');
+          menuLinks.forEach((link) => link.removeAttribute('tabindex'));
+        }
+      };
+
+      navToggle.addEventListener('click', () => {
+        const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+        const nextState = !expanded;
+
+        navToggle.setAttribute('aria-expanded', String(nextState));
+        setMenuState(nextState);
+      });
+
+      syncMenuWithViewport();
+      if (mobileQuery.addEventListener) {
+        mobileQuery.addEventListener('change', syncMenuWithViewport);
+      } else if (mobileQuery.addListener) {
+        mobileQuery.addListener(syncMenuWithViewport);
+      }
+    }
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -41,7 +41,9 @@ body{
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
   height: 64px;
+  position: relative;
 }
 .brand{
   display: inline-flex;
@@ -57,16 +59,42 @@ body{
   background: radial-gradient(circle at 30% 30%, var(--brand-2), var(--brand));
   box-shadow: var(--shadow-soft);
 }
-.nav ul{
+.nav-menu{
+  display: flex;
+  align-items: center;
+}
+.nav-menu ul{
   display: flex; gap: 16px; list-style: none; margin: 0; padding: 0;
 }
 .nav a{
   text-decoration: none; color: var(--text); font-weight: 600; padding: 10px 12px; border-radius: 10px;
 }
+.nav a:focus-visible,
+.nav-toggle:focus-visible{
+  outline: 3px solid var(--brand-2);
+  outline-offset: 2px;
+}
 .nav a:hover{ background: var(--surface); }
 .cta{
   background: linear-gradient(135deg, var(--brand-2), var(--brand));
   color: #fff !important;
+  box-shadow: var(--shadow-soft);
+}
+.nav-toggle{
+  display: none;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .2s ease, box-shadow .2s ease, border-color .2s ease;
+}
+.nav-toggle:hover{
+  background: var(--surface);
   box-shadow: var(--shadow-soft);
 }
 
@@ -145,8 +173,59 @@ footer{ border-top: 1px solid var(--border); background: #fbfcfd; }
 @media (max-width: 960px){
   .hero-inner{ grid-template-columns: 1fr; padding: 40px 0; }
   .cards{ grid-template-columns: repeat(2,1fr); }
-  .nav ul{ display: none; } /* gør det simpelt på mobil */
+  .nav.has-toggle{
+    align-items: center;
+  }
+  .nav.has-toggle .nav-toggle{
+    display: inline-flex;
+  }
+  .nav.has-toggle .nav-menu{
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: #fff;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 0;
+    margin-top: 12px;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(-8px);
+    pointer-events: none;
+    transition: max-height .3s ease, opacity .25s ease, transform .3s ease;
+  }
+  .nav.has-toggle .nav-menu ul{
+    flex-direction: column;
+    gap: 0;
+  }
+  .nav.has-toggle .nav-menu li + li{
+    border-top: 1px solid var(--border);
+  }
+  .nav.has-toggle .nav-menu a{
+    display: block;
+    width: 100%;
+    padding: 14px 20px;
+  }
+  .nav.has-toggle .nav-menu.is-open{
+    opacity: 1;
+    transform: translateY(0);
+    max-height: 420px;
+    pointer-events: auto;
+    padding: 12px 0;
+  }
 }
 @media (max-width: 560px){
   .cards{ grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .nav.has-toggle .nav-menu{
+    transition: none;
+  }
+  .nav.has-toggle .nav-toggle{
+    transition: none;
+  }
 }


### PR DESCRIPTION
## Summary
- add a mobile navigation toggle button and wrap the menu for easier show/hide logic
- implement styles and animation for the collapsible menu across breakpoints
- add a script to manage aria attributes, inert state, and keyboard focus for the menu

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cbeaa29198832a9f6fbc7b46deeb91