### PR TITLE
Move navigation toggle script to external file

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,61 +132,6 @@
       <div>Bygget på indhold fra <a href="https://www.hjernesagen.dk/" target="_blank" rel="noopener noreferrer">Hjernesagen</a> og <a href="https://www.sundhed.dk/" target="_blank" rel="noopener noreferrer">Sundhed.dk</a>.</div>
     </div>
   </footer>
-  <script>
-    const navToggle = document.querySelector('.nav-toggle');
-    const navMenu = document.getElementById('primary-navigation');
-    const navContainer = document.querySelector('.nav');
-
-    if (navToggle && navMenu && navContainer) {
-      navContainer.classList.add('has-toggle');
-      const mobileQuery = window.matchMedia('(max-width: 960px)');
-      const menuLinks = navMenu.querySelectorAll('a');
-
-      const setMenuState = (isOpen) => {
-        navMenu.classList.toggle('is-open', isOpen);
-        navMenu.setAttribute('aria-hidden', String(!isOpen));
-        if (isOpen) {
-          navMenu.removeAttribute('inert');
-        } else {
-          navMenu.setAttribute('inert', '');
-        }
-        menuLinks.forEach((link) => {
-          if (isOpen) {
-            link.removeAttribute('tabindex');
-          } else {
-            link.setAttribute('tabindex', '-1');
-          }
-        });
-      };
-
-      const syncMenuWithViewport = () => {
-        if (mobileQuery.matches) {
-          const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-          setMenuState(expanded);
-        } else {
-          navToggle.setAttribute('aria-expanded', 'false');
-          navMenu.classList.remove('is-open');
-          navMenu.removeAttribute('aria-hidden');
-          navMenu.removeAttribute('inert');
-          menuLinks.forEach((link) => link.removeAttribute('tabindex'));
-        }
-      };
-
-      navToggle.addEventListener('click', () => {
-        const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-        const nextState = !expanded;
-
-        navToggle.setAttribute('aria-expanded', String(nextState));
-        setMenuState(nextState);
-      });
-
-      syncMenuWithViewport();
-      if (mobileQuery.addEventListener) {
-        mobileQuery.addEventListener('change', syncMenuWithViewport);
-      } else if (mobileQuery.addListener) {
-        mobileQuery.addListener(syncMenuWithViewport);
-      }
-    }
-  </script>
+  <script src="nav-toggle.js" defer></script>
 </body>
 </html>

--- a/nav-toggle.js
+++ b/nav-toggle.js
@@ -1,0 +1,54 @@
+const navToggle = document.querySelector('.nav-toggle');
+const navMenu = document.getElementById('primary-navigation');
+const navContainer = document.querySelector('.nav');
+
+if (navToggle && navMenu && navContainer) {
+  navContainer.classList.add('has-toggle');
+  const mobileQuery = window.matchMedia('(max-width: 960px)');
+  const menuLinks = navMenu.querySelectorAll('a');
+
+  const setMenuState = (isOpen) => {
+    navMenu.classList.toggle('is-open', isOpen);
+    navMenu.setAttribute('aria-hidden', String(!isOpen));
+    if (isOpen) {
+      navMenu.removeAttribute('inert');
+    } else {
+      navMenu.setAttribute('inert', '');
+    }
+    menuLinks.forEach((link) => {
+      if (isOpen) {
+        link.removeAttribute('tabindex');
+      } else {
+        link.setAttribute('tabindex', '-1');
+      }
+    });
+  };
+
+  const syncMenuWithViewport = () => {
+    if (mobileQuery.matches) {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      setMenuState(expanded);
+    } else {
+      navToggle.setAttribute('aria-expanded', 'false');
+      navMenu.classList.remove('is-open');
+      navMenu.removeAttribute('aria-hidden');
+      navMenu.removeAttribute('inert');
+      menuLinks.forEach((link) => link.removeAttribute('tabindex'));
+    }
+  };
+
+  navToggle.addEventListener('click', () => {
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    const nextState = !expanded;
+
+    navToggle.setAttribute('aria-expanded', String(nextState));
+    setMenuState(nextState);
+  });
+
+  syncMenuWithViewport();
+  if (mobileQuery.addEventListener) {
+    mobileQuery.addEventListener('change', syncMenuWithViewport);
+  } else if (mobileQuery.addListener) {
+    mobileQuery.addListener(syncMenuWithViewport);
+  }
+}


### PR DESCRIPTION
## Summary
- move the navigation toggle logic into a dedicated nav-toggle.js file that can load under the existing CSP
- reference the new script from index.html with a deferred script tag to preserve behavior

## Testing
- browser_container.run_playwright_script (mobile nav smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68cd8e4edba4832a9396290284f3de21