### PR TITLE
Use block padding for hero and footer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -146,7 +146,7 @@ body{
   grid-template-columns: 1.2fr 1fr;
   gap: 40px;
   align-items: center;
-  padding: 64px 0;
+  padding-block: 64px;
 }
 .eyebrow{ color: var(--brand); font-weight: 700; text-transform: uppercase; letter-spacing: .1em; font-size: 12px; }
 h1{ font-size: clamp(28px, 4vw, 44px); line-height: 1.15; margin: 10px 0 16px; }
@@ -202,12 +202,12 @@ section h2{ font-size: clamp(24px,3vw,32px); margin: 0 0 8px; }
 /* ===== Footer ===== */
 footer{ border-top: 1px solid var(--border); background: #fbfcfd; }
 .foot{
-  display: grid; gap: 10px; padding: 22px 0; color: var(--muted); font-size: 14px;
+  display: grid; gap: 10px; padding-block: 22px; color: var(--muted); font-size: 14px;
 }
 
 /* ===== Responsiv ===== */
 @media (max-width: 960px){
-  .hero-inner{ grid-template-columns: 1fr; padding: 40px 0; }
+  .hero-inner{ grid-template-columns: 1fr; padding-block: 40px; }
   .cards{ grid-template-columns: repeat(2,1fr); }
 }
 


### PR DESCRIPTION
## Summary
- update the hero padding to use block-only spacing so container side gutters remain intact
- mirror the responsive hero padding override with padding-block
- switch the footer padding to padding-block to keep the horizontal container padding

## Testing
- Viewed the page at a mobile width to confirm the hero and footer respect the horizontal gutters

------
https://chatgpt.com/codex/tasks/task_e_68cd96e4c81c832aae13739cb384d587